### PR TITLE
Use Calling assembly as fallback

### DIFF
--- a/Source/LandauMedia.Telemetry/Telemeter.cs
+++ b/Source/LandauMedia.Telemetry/Telemeter.cs
@@ -21,7 +21,7 @@ namespace LandauMedia.Telemetry
 
             try
             {
-                var entryAssembly = Assembly.GetEntryAssembly();
+                var entryAssembly = Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly();
                 var baseName = entryAssembly.GetCustomAttributes(true)
                     .OfType<AssemblyTitleAttribute>()
                     .Select(t => t.Title)


### PR DESCRIPTION
Ich habe versucht das Telemetry in einem Web Projekt zu benuten. Das hat nicht geklappt, das es keine "Assembly.GetEntryAssembly()" gab und eine NullPointException kam.

Als Fallback schlage ich "Assembly.GetCallingAssembly()" vor.
